### PR TITLE
Fix calendar going into update loop

### DIFF
--- a/include/datetime/actions.h
+++ b/include/datetime/actions.h
@@ -56,7 +56,7 @@ public:
 
     virtual void set_location(const std::string& zone, const std::string& name)=0;
 
-    void set_calendar_date(const DateTime&);
+    void set_calendar_date(const DateTime&, bool bUpdateCalendar);
     GActionGroup* action_group();
     const std::shared_ptr<State> state() const;
 

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -130,7 +130,7 @@ void on_calendar_active_changed(GSimpleAction * /*action*/,
     {
         auto self = static_cast<Actions*>(gself);
 
-        self->set_calendar_date(self->state()->clock->localtime());
+        self->set_calendar_date(self->state()->clock->localtime(), true);
     }
 }
 
@@ -143,7 +143,7 @@ void on_calendar_activated(GSimpleAction * /*action*/,
     g_return_if_fail(t != 0);
 
     auto dt = DateTime::Local(t).start_of_day();
-    static_cast<Actions*>(gself)->set_calendar_date(dt);
+    static_cast<Actions*>(gself)->set_calendar_date(dt, false);
 }
 
 GVariant* create_default_header_state()
@@ -272,9 +272,13 @@ void Actions::update_calendar_state()
                                        create_calendar_state(m_state));
 }
 
-void Actions::set_calendar_date(const DateTime& date)
+void Actions::set_calendar_date(const DateTime& date, bool bUpdateCalendar)
 {
-    m_state->calendar_month->month().set(date);
+    if (bUpdateCalendar)
+    {
+        m_state->calendar_month->month().set(date);
+    }
+
     m_state->calendar_upcoming->date().set(date);
 }
 


### PR DESCRIPTION
Clicking on days in other months in the calendar triggers an endless loop where both IDO and the Datetime Indicator try to both reset the widget to the current date, as well as update it to the new date. This commit fixes that.