### PR TITLE
Drop the 'show-clock' setting

### DIFF
--- a/data/org.ayatana.indicator.datetime.gschema.xml.in.in
+++ b/data/org.ayatana.indicator.datetime.gschema.xml.in.in
@@ -6,13 +6,6 @@
         <value nick="custom" value="3" />
     </enum>
     <schema id="org.ayatana.indicator.datetime" path="/org/ayatana/indicator/datetime/" gettext-domain="ayatana-indicator-datetime">
-        <key name="show-clock" type="b">
-            <default>true</default>
-            <summary>Show the clock in the panel</summary>
-            <description>
-              Controls whether the clock indicator appears in the panel or not.
-            </description>
-        </key>
         <key name="time-format" enum="time-enum">
             <default>'locale-default'</default>
             <summary>What the time format should be?</summary>

--- a/data/org.ayatana.indicator.datetime.gschema.xml.in.in
+++ b/data/org.ayatana.indicator.datetime.gschema.xml.in.in
@@ -1,173 +1,173 @@
 <schemalist>
-	<enum id="time-enum">
-		<value nick="locale-default" value="0" />
-		<value nick="12-hour" value="1" />
-		<value nick="24-hour" value="2" />
-		<value nick="custom" value="3" />
-	</enum>
-	<schema id="org.ayatana.indicator.datetime" path="/org/ayatana/indicator/datetime/" gettext-domain="ayatana-indicator-datetime">
-		<key name="show-clock" type="b">
-			<default>true</default>
-			<summary>Show the clock in the panel</summary>
-			<description>
-			  Controls whether the clock indicator appears in the panel or not.
-			</description>
-		</key>
-		<key name="time-format" enum="time-enum">
-			<default>'locale-default'</default>
-			<summary>What the time format should be?</summary>
-			<description>
-			  Controls the time format that is displayed in the indicator.  For almost
-			  all users this should be the default for their locale.  If you think the
-			  setting is wrong for your locale please join or talk to the translation
-			  team for your language.  If you just want something different you can
-			  adjust this to be either 12 or 24 time.  Or, you can use a custom format
-			  string and set the custom-time-format setting.
-			</description>
-		</key>
-		<key name="custom-time-format" type="s">
-			<default>"%l:%M %p"</default>
-			<summary>The format string passed to strftime</summary>
-			<description>
-			  The format of the time and/or date that is visible on the panel when using
-			  the indicator.  For most users this will be a set of predefined values as
-			  determined by the configuration utility, but advanced users can change it
-			  to anything strftime can accept.  Look at the man page on strftime for
-			  more information.
-			</description>
-		</key>
-		<key name="show-seconds" type="b">
-			<default>false</default>
-			<summary>Show the number of seconds in the indicator</summary>
-			<description>
-			  Makes the datetime indicator show the number of seconds in the indicator.
-			  It's important to note that this will cause additional battery drain as
-			  the time will update 60 times as often, so it is not recommended.  Also,
-			  this setting will be ignored if the time-format value is set to custom.
-			</description>
-		</key>
-		<key name="show-day" type="b">
-			<default>false</default>
-			<summary>Show the day of the week in the indicator</summary>
-			<description>
-			  Puts the day of the week on the panel along with the time and/or date
-			  depending on settings.  This setting will be ignored if the time-format
-			  value is set to custom.
-			</description>
-		</key>
-		<key name="show-date" type="b">
-			<default>false</default>
-			<summary>Show the month and date in the indicator</summary>
-			<description>
-			  Puts the month and the date in the panel along with the time and/or day
-			  of the week depending on settings.  This setting will be ignored if the
-			  time-format value is set to custom.
-			</description>
-		</key>
-		<key name="show-year" type="b">
-			<default>false</default>
-			<summary>Show the year in the indicator</summary>
-			<description>
-			  Puts the year in the panel along with the month and the date.
-			  This setting will be ignored if either the time-format value is set to custom
-			  or if show-date is set to false.
-			</description>
-		</key>
-		<key name="show-calendar" type="b">
-			<default>true</default>
-			<summary>Show the monthly calendar in the indicator</summary>
-			<description>
-			  Puts the monthly calendar in indicator-datetime's menu.
-			</description>
-		</key>
-		<key name="show-week-numbers" type="b">
-			<default>false</default>
-			<summary>Show week numbers in calendar</summary>
-			<description>
-			  Shows the week numbers in the monthly calendar in indicator-datetime's menu.
-			</description>
-		</key>
-		<key name="show-events" type="b">
-			<default>true</default>
-			<summary>Show events in the indicator</summary>
-			<description>
-			  Shows events from Evolution in indicator-datetime's menu.
-			</description>
-		</key>
-		<key name="show-auto-detected-location" type="b">
-			<default>false</default>
-			<summary>Show the auto-detected location in the indicator</summary>
-			<description>
-			  Shows your current location (determined from geoclue and /etc/timezone) in indicator-datetime's menu.
-			</description>
-		</key>
-		<key name="show-locations" type="b">
-			<default>false</default>
-			<summary>Show locations in the indicator</summary>
-			<description>
-			  Shows custom defined locations in indicator-datetime's menu.
-			</description>
-		</key>
-		<key name="locations" type="as">
-			<default>['UTC']</default>
-			<summary>A List of locations</summary>
-			<description>
-			  Adds the list of locations the user has configured to display in the
-			  indicator-datetime menu.
-			</description>
-		</key>
-		<key name="timezone-name" type="s">
-			<default>''</default>
-			<summary>The name of the current timezone</summary>
-			<description>
-			  Some timezones can be known by many different cities or names.  This setting describes how the current zone prefers to be named.  Format is "TIMEZONE NAME" (e.g. "America/New_York Boston" to name the New_York zone Boston).
-			</description>
-		</key>
-		<key name="alarm-haptic-feedback" type="s">
-			<default>'pulse'</default>
-			<summary>What kind of haptic feedback, if any, to trigger with an alarm.</summary>
-			<description>
+    <enum id="time-enum">
+        <value nick="locale-default" value="0" />
+        <value nick="12-hour" value="1" />
+        <value nick="24-hour" value="2" />
+        <value nick="custom" value="3" />
+    </enum>
+    <schema id="org.ayatana.indicator.datetime" path="/org/ayatana/indicator/datetime/" gettext-domain="ayatana-indicator-datetime">
+        <key name="show-clock" type="b">
+            <default>true</default>
+            <summary>Show the clock in the panel</summary>
+            <description>
+              Controls whether the clock indicator appears in the panel or not.
+            </description>
+        </key>
+        <key name="time-format" enum="time-enum">
+            <default>'locale-default'</default>
+            <summary>What the time format should be?</summary>
+            <description>
+              Controls the time format that is displayed in the indicator.  For almost
+              all users this should be the default for their locale.  If you think the
+              setting is wrong for your locale please join or talk to the translation
+              team for your language.  If you just want something different you can
+              adjust this to be either 12 or 24 time.  Or, you can use a custom format
+              string and set the custom-time-format setting.
+            </description>
+        </key>
+        <key name="custom-time-format" type="s">
+            <default>"%l:%M %p"</default>
+            <summary>The format string passed to strftime</summary>
+            <description>
+              The format of the time and/or date that is visible on the panel when using
+              the indicator.  For most users this will be a set of predefined values as
+              determined by the configuration utility, but advanced users can change it
+              to anything strftime can accept.  Look at the man page on strftime for
+              more information.
+            </description>
+        </key>
+        <key name="show-seconds" type="b">
+            <default>false</default>
+            <summary>Show the number of seconds in the indicator</summary>
+            <description>
+              Makes the datetime indicator show the number of seconds in the indicator.
+              It's important to note that this will cause additional battery drain as
+              the time will update 60 times as often, so it is not recommended.  Also,
+              this setting will be ignored if the time-format value is set to custom.
+            </description>
+        </key>
+        <key name="show-day" type="b">
+            <default>false</default>
+            <summary>Show the day of the week in the indicator</summary>
+            <description>
+              Puts the day of the week on the panel along with the time and/or date
+              depending on settings.  This setting will be ignored if the time-format
+              value is set to custom.
+            </description>
+        </key>
+        <key name="show-date" type="b">
+            <default>false</default>
+            <summary>Show the month and date in the indicator</summary>
+            <description>
+              Puts the month and the date in the panel along with the time and/or day
+              of the week depending on settings.  This setting will be ignored if the
+              time-format value is set to custom.
+            </description>
+        </key>
+        <key name="show-year" type="b">
+            <default>false</default>
+            <summary>Show the year in the indicator</summary>
+            <description>
+              Puts the year in the panel along with the month and the date.
+              This setting will be ignored if either the time-format value is set to custom
+              or if show-date is set to false.
+            </description>
+        </key>
+        <key name="show-calendar" type="b">
+            <default>true</default>
+            <summary>Show the monthly calendar in the indicator</summary>
+            <description>
+              Puts the monthly calendar in indicator-datetime's menu.
+            </description>
+        </key>
+        <key name="show-week-numbers" type="b">
+            <default>false</default>
+            <summary>Show week numbers in calendar</summary>
+            <description>
+              Shows the week numbers in the monthly calendar in indicator-datetime's menu.
+            </description>
+        </key>
+        <key name="show-events" type="b">
+            <default>true</default>
+            <summary>Show events in the indicator</summary>
+            <description>
+              Shows events from Evolution in indicator-datetime's menu.
+            </description>
+        </key>
+        <key name="show-auto-detected-location" type="b">
+            <default>false</default>
+            <summary>Show the auto-detected location in the indicator</summary>
+            <description>
+              Shows your current location (determined from geoclue and /etc/timezone) in indicator-datetime's menu.
+            </description>
+        </key>
+        <key name="show-locations" type="b">
+            <default>false</default>
+            <summary>Show locations in the indicator</summary>
+            <description>
+              Shows custom defined locations in indicator-datetime's menu.
+            </description>
+        </key>
+        <key name="locations" type="as">
+            <default>['UTC']</default>
+            <summary>A List of locations</summary>
+            <description>
+              Adds the list of locations the user has configured to display in the
+              indicator-datetime menu.
+            </description>
+        </key>
+        <key name="timezone-name" type="s">
+            <default>''</default>
+            <summary>The name of the current timezone</summary>
+            <description>
+              Some timezones can be known by many different cities or names.  This setting describes how the current zone prefers to be named.  Format is "TIMEZONE NAME" (e.g. "America/New_York Boston" to name the New_York zone Boston).
+            </description>
+        </key>
+        <key name="alarm-haptic-feedback" type="s">
+            <default>'pulse'</default>
+            <summary>What kind of haptic feedback, if any, to trigger with an alarm.</summary>
+            <description>
                           What kind of haptic feedback, if any, to trigger with an alarm.
                           Two modes are currently supported: 'pulse', 'none'.
-			</description>
-		</key>
-		<key name="calendar-default-sound" type="s">
-			<default>'@CALENDAR_DEFAULT_SOUND@'</default>
-			<_summary>The calendar's default sound file.</_summary>
-			<_description>
-			  If a calendar or reminder event doesn't specify its own sound file, this file will be used as the fallback sound.
-			</_description>
-		</key>
-		<key name="alarm-default-sound" type="s">
-			<default>'@ALARM_DEFAULT_SOUND@'</default>
-			<summary>The alarm's default sound file.</summary>
-			<description>
-			  If an alarm doesn't specify its own sound file, this file will be used as the fallback sound.
-			</description>
-		</key>
-		<key name="alarm-default-volume" type="u">
-			<range min="1" max="100"/>
-			<default>50</default>
-			<summary>The alarm's default volume level.</summary>
-			<description>
-			  The volume at which alarms will be played.
-			</description>
-		</key>
-		<key name="alarm-duration-minutes" type="u">
-			<range min="1" max="60"/>
-			<default>10</default>
-			<summary>The alarm's duration.</summary>
-			<description>
-			  How long the alarm's sound will be looped if its snap decision is not dismissed by the user.
-			</description>
-		</key>
-		<key name="snooze-duration-minutes" type="u">
-			<range min="1" max="20"/>
-			<default>5</default>
-			<summary>The snooze duration.</summary>
-			<description>
-			  How long to wait when the user hits the Snooze button.
-			</description>
-		</key>
-	</schema>
+            </description>
+        </key>
+        <key name="calendar-default-sound" type="s">
+            <default>'@CALENDAR_DEFAULT_SOUND@'</default>
+            <_summary>The calendar's default sound file.</_summary>
+            <_description>
+              If a calendar or reminder event doesn't specify its own sound file, this file will be used as the fallback sound.
+            </_description>
+        </key>
+        <key name="alarm-default-sound" type="s">
+            <default>'@ALARM_DEFAULT_SOUND@'</default>
+            <summary>The alarm's default sound file.</summary>
+            <description>
+              If an alarm doesn't specify its own sound file, this file will be used as the fallback sound.
+            </description>
+        </key>
+        <key name="alarm-default-volume" type="u">
+            <range min="1" max="100"/>
+            <default>50</default>
+            <summary>The alarm's default volume level.</summary>
+            <description>
+              The volume at which alarms will be played.
+            </description>
+        </key>
+        <key name="alarm-duration-minutes" type="u">
+            <range min="1" max="60"/>
+            <default>10</default>
+            <summary>The alarm's duration.</summary>
+            <description>
+              How long the alarm's sound will be looped if its snap decision is not dismissed by the user.
+            </description>
+        </key>
+        <key name="snooze-duration-minutes" type="u">
+            <range min="1" max="20"/>
+            <default>5</default>
+            <summary>The snooze duration.</summary>
+            <description>
+              How long to wait when the user hits the Snooze button.
+            </description>
+        </key>
+    </schema>
 </schemalist>

--- a/include/datetime/settings-live.h
+++ b/include/datetime/settings-live.h
@@ -44,7 +44,6 @@ private:
     void update_custom_time_format();
     void update_locations();
     void update_show_calendar();
-    void update_show_clock();
     void update_show_date();
     void update_show_day();
     void update_show_detected_locations();

--- a/include/datetime/settings-shared.h
+++ b/include/datetime/settings-shared.h
@@ -31,7 +31,6 @@ typedef enum
 TimeFormatMode;
 
 #define SETTINGS_INTERFACE              "org.ayatana.indicator.datetime"
-#define SETTINGS_SHOW_CLOCK_S           "show-clock"
 #define SETTINGS_TIME_FORMAT_S          "time-format"
 #define SETTINGS_SHOW_SECONDS_S         "show-seconds"
 #define SETTINGS_SHOW_DAY_S             "show-day"

--- a/include/datetime/settings.h
+++ b/include/datetime/settings.h
@@ -45,7 +45,6 @@ public:
     core::Property<std::string> custom_time_format;
     core::Property<std::vector<std::string>> locations;
     core::Property<bool> show_calendar;
-    core::Property<bool> show_clock;
     core::Property<bool> show_date;
     core::Property<bool> show_day;
     core::Property<bool> show_detected_location;

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -94,10 +94,6 @@ protected:
             update_section(Appointments); // uses formatter.relative_format()
             update_section(Locations); // uses formatter.relative_format()
         });
-        m_state->settings->show_clock.changed().connect([this](bool){
-            update_header(); // update header's label
-            update_section(Locations); // locations' relative time may have changed
-        });
         m_state->settings->show_calendar.changed().connect([this](bool){
             update_section(Calendar);
         });
@@ -465,7 +461,6 @@ protected:
 
     GVariant* create_header_state()
     {
-        const auto visible = m_state->settings->show_clock.get();
         const auto title = _("Date and Time");
         auto label = g_variant_new_string(m_formatter->header.get().c_str());
 
@@ -474,7 +469,7 @@ protected:
         g_variant_builder_add(&b, "{sv}", "accessible-desc", label);
         g_variant_builder_add(&b, "{sv}", "label", label);
         g_variant_builder_add(&b, "{sv}", "title", g_variant_new_string(title));
-        g_variant_builder_add(&b, "{sv}", "visible", g_variant_new_boolean(visible));
+        g_variant_builder_add(&b, "{sv}", "visible", g_variant_new_boolean(TRUE));
         return g_variant_builder_end(&b);
     }
 };

--- a/src/settings-live.cpp
+++ b/src/settings-live.cpp
@@ -41,7 +41,6 @@ LiveSettings::LiveSettings():
     update_custom_time_format();
     update_locations();
     update_show_calendar();
-    update_show_clock();
     update_show_date();
     update_show_day();
     update_show_detected_locations();
@@ -76,10 +75,6 @@ LiveSettings::LiveSettings():
 
     show_calendar.changed().connect([this](bool value){
         g_settings_set_boolean(m_settings, SETTINGS_SHOW_CALENDAR_S, value);
-    });
-
-    show_clock.changed().connect([this](bool value){
-        g_settings_set_boolean(m_settings, SETTINGS_SHOW_CLOCK_S, value);
     });
 
     show_date.changed().connect([this](bool value){
@@ -172,11 +167,6 @@ void LiveSettings::update_show_calendar()
 {
     const auto val = g_settings_get_boolean(m_settings, SETTINGS_SHOW_CALENDAR_S);
     show_calendar.set(val);
-}
-
-void LiveSettings::update_show_clock()
-{
-    show_clock.set(g_settings_get_boolean(m_settings, SETTINGS_SHOW_CLOCK_S));
 }
 
 void LiveSettings::update_show_date()
@@ -284,9 +274,7 @@ void LiveSettings::on_changed(GSettings* /*settings*/,
 
 void LiveSettings::update_key(const std::string& key)
 {
-    if (key == SETTINGS_SHOW_CLOCK_S)
-        update_show_clock();
-    else if (key == SETTINGS_LOCATIONS_S)
+    if (key == SETTINGS_LOCATIONS_S)
         update_locations();
     else if (key == SETTINGS_TIME_FORMAT_S)
         update_time_format_mode();

--- a/tests/test-settings.cpp
+++ b/tests/test-settings.cpp
@@ -138,7 +138,6 @@ TEST_F(SettingsFixture, BoolProperties)
 {
     TestBoolProperty(m_settings->show_seconds, SETTINGS_SHOW_SECONDS_S);
     TestBoolProperty(m_settings->show_calendar, SETTINGS_SHOW_CALENDAR_S);
-    TestBoolProperty(m_settings->show_clock, SETTINGS_SHOW_CLOCK_S);
     TestBoolProperty(m_settings->show_date, SETTINGS_SHOW_DATE_S);
     TestBoolProperty(m_settings->show_day, SETTINGS_SHOW_DAY_S);
     TestBoolProperty(m_settings->show_detected_location, SETTINGS_SHOW_DETECTED_S);


### PR DESCRIPTION
May, or may not  be related to #16 , but definitely future-proofs the indicator: This ensures we always have a label with text.