### PR TITLE
Use appointment text width from GSettings

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -114,6 +114,16 @@ variables:
     -enable-checker alpha.core.FixedAddr
     -enable-checker security.insecureAPI.strcpy"'
 
+before_scripts:
+  - cd ${START_DIR}
+  - if [ ! -d libayatana-common-build ]; then
+  -     git clone --depth 1  https://github.com/AyatanaIndicators/libayatana-common.git libayatana-common-build
+  - fi
+  - cd libayatana-common-build
+  - cmake . -DCMAKE_INSTALL_PREFIX=/usr
+  - make
+  - make install
+
 build_scripts:
   - if [ ${DISTRO_NAME} == "debian" ];then
   -     export CFLAGS+=" -Wsign-compare -Wunused-parameter"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option (ENABLE_COVERAGE "Generate lcov code coverage reports." OFF)
 ##  GNU standard installation directories
 ##
 
+include (GNUInstallDirs)
 set (CMAKE_INSTALL_PKGLIBEXECDIR "${CMAKE_INSTALL_LIBEXECDIR}/${CMAKE_PROJECT_NAME}")
 set (CMAKE_INSTALL_FULL_PKGLIBEXECDIR "${CMAKE_INSTALL_FULL_LIBEXECDIR}/${CMAKE_PROJECT_NAME}")
 
@@ -41,6 +42,7 @@ include (CheckIncludeFile)
 include (FindPkgConfig)
 
 pkg_check_modules (SERVICE_DEPS REQUIRED
+                   libayatana-common>=0.9.3
                    glib-2.0>=2.36
                    gio-unix-2.0>=2.36
                    libical>=0.48


### PR DESCRIPTION
- CMakeLists.txt: Add libayatana-common dependency
- src/menu.cpp: Pipe appointment strings through ayatana_common_utils_ellipsize + add GSettings watcher for max-menu-text-length

fixes https://github.com/AyatanaIndicators/ayatana-indicator-datetime/issues/29