### PR TITLE
If possible, avoid deprecated g_time_zone_new

### DIFF
--- a/src/clock-live.cpp
+++ b/src/clock-live.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published
@@ -15,6 +16,7 @@
  *
  * Authors:
  *   Charles Kerr <charles.kerr@canonical.com>
+ *   Robert Tari <robert@tari.in>
  */
 
 #include <datetime/clock.h>
@@ -162,7 +164,16 @@ private:
     void setTimezone(const std::string& str)
     {
         g_clear_pointer(&m_gtimezone, g_time_zone_unref);
+        #if GLIB_CHECK_VERSION(2, 68, 0)
+        m_gtimezone = g_time_zone_new_identifier(str.c_str());
+
+        if (m_gtimezone == NULL)
+        {
+            m_gtimezone = g_time_zone_new_utc();
+        }
+        #else
         m_gtimezone = g_time_zone_new(str.c_str());
+        #endif
         m_owner.minute_changed();
     }
 

--- a/src/date-time.cpp
+++ b/src/date-time.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published
@@ -15,6 +16,7 @@
  *
  * Authors:
  *   Charles Kerr <charles.kerr@canonical.com>
+ *   Robert Tari <robert@tari.in>
  */
 
 #include <datetime/date-time.h>
@@ -105,7 +107,16 @@ DateTime DateTime::Local(int year, int month, int day, int hour, int minute, dou
 
 DateTime DateTime::to_timezone(const std::string& zone) const
 {
+    #if GLIB_CHECK_VERSION(2, 68, 0)
+    auto gtz = g_time_zone_new_identifier(zone.c_str());
+
+    if (gtz == NULL)
+    {
+        gtz = g_time_zone_new_utc();
+    }
+    #else
     auto gtz = g_time_zone_new(zone.c_str());
+    #endif
     auto gdt = g_date_time_to_timezone(get(), gtz);
     DateTime dt(gtz, gdt);
     g_time_zone_unref(gtz);

--- a/src/engine-eds.cpp
+++ b/src/engine-eds.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2014 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published
@@ -15,6 +16,7 @@
  *
  * Authors:
  *   Charles Kerr <charles.kerr@canonical.com>
+ *   Robert Tari <robert@tari.in>
  */
 
 #include <datetime/engine-eds.h>
@@ -913,7 +915,20 @@ private:
         if (identifier == nullptr)
             g_warning("Unrecognized TZID: '%s'", tzid);
         else
-            return g_time_zone_new(identifier);
+        {
+            #if GLIB_CHECK_VERSION(2, 68, 0)
+            auto pZone = g_time_zone_new_identifier(identifier);
+
+            if (pZone == NULL)
+            {
+                pZone = g_time_zone_new_utc();
+            }
+            #else
+            auto pZone = g_time_zone_new(identifier);
+            #endif
+
+            return pZone;
+        }
 
         return nullptr;
     }

--- a/src/locations.cpp
+++ b/src/locations.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published
@@ -15,6 +16,7 @@
  *
  * Authors:
  *   Charles Kerr <charles.kerr@canonical.com>
+ *   Robert Tari <robert@tari.in>
  */
 
 #include <datetime/locations.h>
@@ -47,7 +49,16 @@ Location::Location(const std::string& zone_, const std::string& name_):
     m_zone(zone_),
     m_name(name_)
 {
+    #if GLIB_CHECK_VERSION(2, 68, 0)
+    auto gzone = g_time_zone_new_identifier(zone().c_str());
+
+    if (gzone == NULL)
+    {
+        gzone = g_time_zone_new_utc();
+    }
+    #else
     auto gzone = g_time_zone_new (zone().c_str());
+    #endif
     auto gtime = g_date_time_new_now (gzone);
     m_offset = g_date_time_get_utc_offset (gtime);
     g_date_time_unref (gtime);

--- a/tests/test-clock.cpp
+++ b/tests/test-clock.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published
@@ -15,6 +16,7 @@
  *
  * Authors:
  *   Charles Kerr <charles.kerr@canonical.com>
+ *   Robert Tari <robert@tari.in>
  */
 
 #include <datetime/clock.h>
@@ -77,8 +79,16 @@ TEST_F(ClockFixture, TimezoneChangeTriggersSkew)
     auto timezone_ = std::make_shared<MockTimezone>();
     timezone_->timezone.set("America/New_York");
     LiveClock clock(timezone_);
+    #if GLIB_CHECK_VERSION(2, 68, 0)
+    auto tz_nyc = g_time_zone_new_identifier("America/New_York");
 
+    if (tz_nyc == NULL)
+    {
+        tz_nyc = g_time_zone_new_utc();
+    }
+    #else
     auto tz_nyc = g_time_zone_new("America/New_York");
+    #endif
     auto now_nyc = g_date_time_new_now(tz_nyc);
     auto now = clock.localtime();
     EXPECT_EQ(g_date_time_get_utc_offset(now_nyc), g_date_time_get_utc_offset(now.get()));
@@ -95,8 +105,16 @@ TEST_F(ClockFixture, TimezoneChangeTriggersSkew)
                    return G_SOURCE_REMOVE;
                }, timezone_.get());
     g_main_loop_run(loop);
+    #if GLIB_CHECK_VERSION(2, 68, 0)
+    auto tz_la = g_time_zone_new_identifier("America/Los_Angeles");
 
+    if (tz_la == NULL)
+    {
+        tz_la = g_time_zone_new_utc();
+    }
+    #else
     auto tz_la = g_time_zone_new("America/Los_Angeles");
+    #endif
     auto now_la = g_date_time_new_now(tz_la);
     now = clock.localtime();
     EXPECT_EQ(g_date_time_get_utc_offset(now_la), g_date_time_get_utc_offset(now.get()));

--- a/tests/test-datetime.cpp
+++ b/tests/test-datetime.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published
@@ -15,6 +16,7 @@
  *
  * Authors:
  *   Charles Kerr <charles.kerr@canonical.com>
+ *   Robert Tari <robert@tari.in>
  */
 
 #include <datetime/date-time.h>

--- a/tests/test-eds-ics-all-day-events.cpp
+++ b/tests/test-eds-ics-all-day-events.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published
@@ -15,6 +16,7 @@
  *
  * Authors:
  *   Charles Kerr <charles.kerr@canonical.com>
+ *   Robert Tari <robert@tari.in>
  */
 
 #include <algorithm>
@@ -46,7 +48,16 @@ TEST_F(VAlarmFixture, MultipleAppointments)
     // we need a consistent timezone for the planner and our local DateTimes
     constexpr char const * zone_str {"America/Chicago"};
     auto tz = std::make_shared<MockTimezone>(zone_str);
+    #if GLIB_CHECK_VERSION(2, 68, 0)
+    auto gtz = g_time_zone_new_identifier(zone_str);
+
+    if (gtz == NULL)
+    {
+        gtz = g_time_zone_new_utc();
+    }
+    #else
     auto gtz = g_time_zone_new(zone_str);
+    #endif
 
     // make a planner that looks at the first half of 2015 in EDS
     auto planner = std::make_shared<SimpleRangePlanner>(engine, tz);

--- a/tests/test-eds-ics-missing-trigger.cpp
+++ b/tests/test-eds-ics-missing-trigger.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published
@@ -15,6 +16,7 @@
  *
  * Authors:
  *   Charles Kerr <charles.kerr@canonical.com>
+ *   Robert Tari <robert@tari.in>
  */
 
 #include <algorithm>
@@ -46,7 +48,16 @@ TEST_F(VAlarmFixture, MissingTriggers)
     // we need a consistent timezone for the planner and our local DateTimes
     constexpr char const * zone_str {"America/Chicago"};
     auto tz = std::make_shared<MockTimezone>(zone_str);
+    #if GLIB_CHECK_VERSION(2, 68, 0)
+    auto gtz = g_time_zone_new_identifier(zone_str);
+
+    if (gtz == NULL)
+    {
+        gtz = g_time_zone_new_utc();
+    }
+    #else
     auto gtz = g_time_zone_new(zone_str);
+    #endif
 
     // make a planner that looks at the first half of 2015 in EDS
     auto planner = std::make_shared<SimpleRangePlanner>(engine, tz);

--- a/tests/test-eds-ics-nonrepeating-events.cpp
+++ b/tests/test-eds-ics-nonrepeating-events.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published
@@ -15,6 +16,7 @@
  *
  * Authors:
  *   Charles Kerr <charles.kerr@canonical.com>
+ *   Robert Tari <robert@tari.in>
  */
 
 #include <algorithm>
@@ -46,7 +48,16 @@ TEST_F(VAlarmFixture, MultipleAppointments)
     // we need a consistent timezone for the planner and our local DateTimes
     constexpr char const * zone_str {"America/Chicago"};
     auto tz = std::make_shared<MockTimezone>(zone_str);
+    #if GLIB_CHECK_VERSION(2, 68, 0)
+    auto gtz = g_time_zone_new_identifier(zone_str);
+
+    if (gtz == NULL)
+    {
+        gtz = g_time_zone_new_utc();
+    }
+    #else
     auto gtz = g_time_zone_new(zone_str);
+    #endif
 
     // make a planner that looks at the first half of 2015 in EDS
     auto planner = std::make_shared<SimpleRangePlanner>(engine, tz);

--- a/tests/test-eds-ics-repeating-events.cpp
+++ b/tests/test-eds-ics-repeating-events.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published
@@ -15,6 +16,7 @@
  *
  * Authors:
  *   Charles Kerr <charles.kerr@canonical.com>
+ *   Robert Tari <robert@tari.in>
  */
 
 #include <algorithm>
@@ -46,7 +48,16 @@ TEST_F(VAlarmFixture, MultipleAppointments)
     // we need a consistent timezone for the planner and our local DateTimes
     constexpr char const * zone_str {"America/Chicago"};
     auto tz = std::make_shared<MockTimezone>(zone_str);
+    #if GLIB_CHECK_VERSION(2, 68, 0)
+    auto gtz = g_time_zone_new_identifier(zone_str);
+
+    if (gtz == NULL)
+    {
+        gtz = g_time_zone_new_utc();
+    }
+    #else
     auto gtz = g_time_zone_new(zone_str);
+    #endif
 
     // make a planner that looks at the first half of 2015 in EDS
     auto planner = std::make_shared<SimpleRangePlanner>(engine, tz);

--- a/tests/test-eds-ics-repeating-valarms.cpp
+++ b/tests/test-eds-ics-repeating-valarms.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published
@@ -15,6 +16,7 @@
  *
  * Authors:
  *   Charles Kerr <charles.kerr@canonical.com>
+ *   Robert Tari <robert@tari.in>
  */
 
 #include <algorithm>
@@ -46,7 +48,16 @@ TEST_F(VAlarmFixture, MultipleAppointments)
     // we need a consistent timezone for the planner and our local DateTimes
     constexpr char const * zone_str {"America/Chicago"};
     auto tz = std::make_shared<MockTimezone>(zone_str);
+    #if GLIB_CHECK_VERSION(2, 68, 0)
+    auto gtz = g_time_zone_new_identifier(zone_str);
+
+    if (gtz == NULL)
+    {
+        gtz = g_time_zone_new_utc();
+    }
+    #else
     auto gtz = g_time_zone_new(zone_str);
+    #endif
 
     // make a planner that looks at the first half of 2015 in EDS
     auto planner = std::make_shared<SimpleRangePlanner>(engine, tz);

--- a/tests/test-eds-ics-tzids-2.cpp
+++ b/tests/test-eds-ics-tzids-2.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published
@@ -15,6 +16,7 @@
  *
  * Authors:
  *   Charles Kerr <charles.kerr@canonical.com>
+ *   Robert Tari <robert@tari.in>
  */
 
 #include <algorithm>
@@ -46,7 +48,16 @@ TEST_F(VAlarmFixture, MultipleAppointments)
     // we need a consistent timezone for the planner and our local DateTimes
     constexpr char const * zone_str {"America/Los_Angeles"};
     auto tz = std::make_shared<MockTimezone>(zone_str);
+    #if GLIB_CHECK_VERSION(2, 68, 0)
+    auto gtz = g_time_zone_new_identifier(zone_str);
+
+    if (gtz == NULL)
+    {
+        gtz = g_time_zone_new_utc();
+    }
+    #else
     auto gtz = g_time_zone_new(zone_str);
+    #endif
 
     // make a planner that looks at the first half of 2015 in EDS
     auto planner = std::make_shared<SimpleRangePlanner>(engine, tz);

--- a/tests/test-eds-ics-tzids.cpp
+++ b/tests/test-eds-ics-tzids.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015 Canonical Ltd.
+ * Copyright 2021 Robert Tari
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3, as published
@@ -15,6 +16,7 @@
  *
  * Authors:
  *   Charles Kerr <charles.kerr@canonical.com>
+ *   Robert Tari <robert@tari.in>
  */
 
 #include <algorithm>
@@ -46,7 +48,16 @@ TEST_F(VAlarmFixture, MultipleAppointments)
     // we need a consistent timezone for the planner and our local DateTimes
     constexpr char const * zone_str {"Europe/Berlin"};
     auto tz = std::make_shared<MockTimezone>(zone_str);
+    #if GLIB_CHECK_VERSION(2, 68, 0)
+    auto gtz = g_time_zone_new_identifier(zone_str);
+
+    if (gtz == NULL)
+    {
+        gtz = g_time_zone_new_utc();
+    }
+    #else
     auto gtz = g_time_zone_new(zone_str);
+    #endif
 
     // make a planner that looks at the first half of 2015 in EDS
     auto planner = std::make_shared<SimpleRangePlanner>(engine, tz);


### PR DESCRIPTION
Needs rebasing after https://github.com/AyatanaIndicators/ayatana-indicator-datetime/pull/38 has been merged