### PR TITLE
Allow autostart for Budgie Desktop

### DIFF
--- a/data/ayatana-indicator-datetime.desktop.in
+++ b/data/ayatana-indicator-datetime.desktop.in
@@ -2,7 +2,7 @@
 Type=Application
 Name=Ayatana Indicator Date & Time
 Exec=@pkglibexecdir@/ayatana-indicator-datetime-service
-OnlyShowIn=MATE;Unity;XFCE;Pantheon;
+OnlyShowIn=MATE;Unity;XFCE;Pantheon;Budgie
 NoDisplay=true
 StartupNotify=false
 Terminal=false


### PR DESCRIPTION
Hi,

 for the next release of our budgie-indicator-applet to Debian I will be enabling the support of this ayatana indicator.  This is because users have requested the abilities of this indicator for the budgie-desktop.

Please can you review and accept this PR to ensure the service is autostarted for budgie users.

thx