### PR TITLE
Add option to show/hide alarms

### DIFF
--- a/data/org.ayatana.indicator.datetime.gschema.xml.in
+++ b/data/org.ayatana.indicator.datetime.gschema.xml.in
@@ -87,6 +87,13 @@
               Shows events from Evolution in indicator-datetime's menu.
             </description>
         </key>
+        <key name="show-alarms" type="b">
+            <default>true</default>
+            <summary>Show alarms in the indicator</summary>
+            <description>
+              Shows alarms in the events list in indicator-datetime's menu.
+            </description>
+        </key>
         <key name="show-auto-detected-location" type="b">
             <default>false</default>
             <summary>Show the auto-detected location in the indicator</summary>

--- a/include/datetime/menu.h
+++ b/include/datetime/menu.h
@@ -53,7 +53,8 @@ public:
     static std::vector<Appointment> get_display_appointments(
         const std::vector<Appointment>&,
         const DateTime& start,
-        unsigned int max_items=5);
+        unsigned int max_items=5,
+        const bool include_alarms=true);
 
 protected:
     Menu (Profile profile_in, const std::string& name_in);

--- a/include/datetime/settings-live.h
+++ b/include/datetime/settings-live.h
@@ -52,6 +52,7 @@ private:
     void update_show_day();
     void update_show_detected_locations();
     void update_show_events();
+    void update_show_alarms();
     void update_show_locations();
     void update_show_seconds();
     void update_show_week_numbers();

--- a/include/datetime/settings-shared.h
+++ b/include/datetime/settings-shared.h
@@ -40,6 +40,7 @@ TimeFormatMode;
 #define SETTINGS_SHOW_CALENDAR_S        "show-calendar"
 #define SETTINGS_SHOW_WEEK_NUMBERS_S    "show-week-numbers"
 #define SETTINGS_SHOW_EVENTS_S          "show-events"
+#define SETTINGS_SHOW_ALARMS_S          "show-alarms"
 #define SETTINGS_SHOW_LOCATIONS_S       "show-locations"
 #define SETTINGS_SHOW_DETECTED_S        "show-auto-detected-location"
 #define SETTINGS_LOCATIONS_S            "locations"

--- a/include/datetime/settings.h
+++ b/include/datetime/settings.h
@@ -49,6 +49,7 @@ public:
     core::Property<bool> show_day;
     core::Property<bool> show_detected_location;
     core::Property<bool> show_events;
+    core::Property<bool> show_alarms;
     core::Property<bool> show_locations;
     core::Property<bool> show_seconds;
     core::Property<bool> show_week_numbers;

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -142,7 +142,10 @@ GVariant* create_calendar_state(const std::shared_ptr<State>& state)
 {
     gboolean days[32] = { 0 };
     for (const auto& appt : state->calendar_month->appointments().get())
-        days[appt.begin.day_of_month()] = true;
+        if (!appt.is_alarm() || state->settings->show_alarms.get())
+        {
+            days[appt.begin.day_of_month()] = true;
+        }
 
     GVariantBuilder day_builder;
     g_variant_builder_init(&day_builder, G_VARIANT_TYPE("ai"));

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -72,13 +72,14 @@ GMenuModel* Menu::menu_model()
 std::vector<Appointment>
 Menu::get_display_appointments(const std::vector<Appointment>& appointments_in,
                                const DateTime& now,
-                               unsigned int max_items)
+                               unsigned int max_items,
+                               const bool include_alarms)
 {
     std::vector<Appointment> appointments;
     std::copy_if(appointments_in.begin(),
                  appointments_in.end(),
                  std::back_inserter(appointments),
-                 [now](const Appointment& a){return a.end >= now;});
+                 [now, include_alarms](const Appointment& a){return a.end >= now && (!a.is_alarm() || include_alarms);});
 
     if (appointments.size() > max_items)
     {
@@ -186,6 +187,9 @@ protected:
         m_state->settings->show_events.changed().connect([this](bool){
             update_section(Appointments); // showing events got toggled
         });
+        m_state->settings->show_alarms.changed().connect([this](bool){
+            update_section(Appointments); // showing alarms got toggled
+        });
         m_state->calendar_upcoming->date().changed().connect([this](const DateTime&){
             update_upcoming(); // our m_upcoming is planner->upcoming() filtered by time
         });
@@ -240,7 +244,9 @@ protected:
 
         auto upcoming = get_display_appointments(
             m_state->calendar_upcoming->appointments().get(),
-            begin
+            begin,
+            5,
+            m_state->settings->show_alarms.get()
         );
 
         if (m_upcoming != upcoming)
@@ -268,10 +274,6 @@ protected:
         return m_serialized_alarm_icon;
     }
 
-    std::vector<Appointment> m_upcoming;
-
-private:
-
     GVariant* get_serialized_calendar_icon()
     {
         if (G_UNLIKELY(m_serialized_calendar_icon == nullptr))
@@ -283,6 +285,10 @@ private:
 
         return m_serialized_calendar_icon;
     }
+
+    std::vector<Appointment> m_upcoming;
+
+private:
 
     void create_gmenu()
     {
@@ -601,6 +607,7 @@ protected:
     {
         // are there alarms?
         bool has_alarms = false;
+        bool has_non_alarm_events = false;
         for(const auto& appointment : m_upcoming)
         {
             has_alarms = appointment.is_alarm();
@@ -609,19 +616,33 @@ protected:
             {
                 break;
             }
+            else
+            {
+                has_non_alarm_events = true;
+            }
         }
+
 
         GVariantBuilder b;
         g_variant_builder_init(&b, G_VARIANT_TYPE_VARDICT);
         g_variant_builder_add(&b, "{sv}", "title", g_variant_new_string (_("Time and Date")));
         g_variant_builder_add(&b, "{sv}", "visible", g_variant_new_boolean (TRUE));
-        if (has_alarms)
+        if (has_alarms || has_non_alarm_events)
+
         {
             auto label = m_formatter->header.get();
-            auto a11y = g_strdup_printf(_("%s (has alarms)"), label.c_str());
+            auto a11y = g_strdup_printf(_("%s (has events)"), label.c_str());
             g_variant_builder_add(&b, "{sv}", "label", g_variant_new_string(label.c_str()));
             g_variant_builder_add(&b, "{sv}", "accessible-desc", g_variant_new_take_string(a11y));
-            g_variant_builder_add(&b, "{sv}", "icon", get_serialized_alarm_icon());
+
+            if (has_alarms && m_state->settings->show_alarms.get())
+            {
+                g_variant_builder_add(&b, "{sv}", "icon", get_serialized_alarm_icon());
+            }
+            else
+            {
+                g_variant_builder_add(&b, "{sv}", "icon", get_serialized_calendar_icon());
+            }
         }
         else
         {

--- a/src/settings-live.cpp
+++ b/src/settings-live.cpp
@@ -47,6 +47,7 @@ LiveSettings::LiveSettings():
     update_show_day();
     update_show_detected_locations();
     update_show_events();
+    update_show_alarms();
     update_show_locations();
     update_show_seconds();
     update_show_week_numbers();
@@ -115,6 +116,10 @@ LiveSettings::LiveSettings():
 
     show_events.changed().connect([this](bool value){
         g_settings_set_boolean(m_settings, SETTINGS_SHOW_EVENTS_S, value);
+    });
+
+    show_alarms.changed().connect([this](bool value){
+        g_settings_set_boolean(m_settings, SETTINGS_SHOW_ALARMS_S, value);
     });
 
     show_locations.changed().connect([this](bool value){
@@ -237,6 +242,12 @@ void LiveSettings::update_show_events()
 {
     const auto val = g_settings_get_boolean(m_settings, SETTINGS_SHOW_EVENTS_S);
     show_events.set(val);
+}
+
+void LiveSettings::update_show_alarms()
+{
+    const auto val = g_settings_get_boolean(m_settings, SETTINGS_SHOW_ALARMS_S);
+    show_alarms.set(val);
 }
 
 void LiveSettings::update_show_locations()
@@ -415,6 +426,8 @@ void LiveSettings::update_key_ccid(const std::string& key)
         update_show_week_numbers();
     else if (key == SETTINGS_SHOW_EVENTS_S)
         update_show_events();
+    else if (key == SETTINGS_SHOW_ALARMS_S)
+        update_show_alarms();
     else if (key == SETTINGS_SHOW_LOCATIONS_S)
         update_show_locations();
     else if (key == SETTINGS_SHOW_DETECTED_S)

--- a/tests/test-menus.cpp
+++ b/tests/test-menus.cpp
@@ -272,6 +272,19 @@ private:
         for (int i=0, n=appointments.size(); i<n; i++)
             InspectAppointmentMenuItem(section, first_appt_index+i, appointments[i]);
 
+        // there shouldn't be any alarms when "show alarms" is false
+        bool has_alarms = false;
+
+        m_state->settings->show_alarms.set(false);
+
+        for (int i=0, n=appointments.size(); i<n; i++)
+            if((has_alarms = appointments[i].is_alarm()))
+                break;            
+
+        EXPECT_FALSE(has_alarms);
+
+        m_state->settings->show_alarms.set(true);
+
         //g_clear_object(&section);
         //g_clear_object(&submenu);
     }


### PR DESCRIPTION
The new setting can show or hide alarms in the events list and calendar dots.

Forward port for https://github.com/ubports/indicator-datetime/pull/40 required for https://gitlab.com/ubports/development/core/lomiri-system-settings/-/merge_requests/423

Requires #117 to actually test this on mobile devices