### PR TITLE
tests/test-menus: Fix build

### DIFF
--- a/tests/test-menus.cpp
+++ b/tests/test-menus.cpp
@@ -338,11 +338,11 @@ private:
     void InspectPhoneAppointments(GMenuModel* menu_model, bool can_open_planner)
     {
         auto submenu = g_menu_model_get_item_link(menu_model, 0, G_MENU_LINK_SUBMENU);
-        
+
         // there shouldn't be any menuitems when "show events" is false
         m_state->settings->show_events.set(false);
         wait_msec();
-        section = g_menu_model_get_item_link(submenu, Menu::Appointments, G_MENU_LINK_SECTION);
+        auto section = g_menu_model_get_item_link(submenu, Menu::Appointments, G_MENU_LINK_SECTION);
         EXPECT_EQ(0, g_menu_model_get_n_items(section));
         g_clear_object(&section);
 
@@ -353,7 +353,7 @@ private:
         wait_msec(); // wait a moment for the menu to update
 
         // check that there's a "clock app" menuitem even when there are no appointments
-        auto section = g_menu_model_get_item_link(submenu, Menu::Appointments, G_MENU_LINK_SECTION);
+        section = g_menu_model_get_item_link(submenu, Menu::Appointments, G_MENU_LINK_SECTION);
         const char* expected_action = "phone.open-alarm-app";
         EXPECT_EQ(1, g_menu_model_get_n_items(section));
         gchar* action = nullptr;


### PR DESCRIPTION
Fixes compilation of `tests/test-menus.cpp`: https://github.com/AyatanaIndicators/ayatana-indicator-datetime/pull/117#discussion_r1438760086

The test is borked when you actually try to run it though, ending in a segfault. But at least it won't cause the entire build to fail now.

<details>
  <summary>Log</summary>

```
14/20 Test #14: test-menus ...................................***Exception: SegFault  0.92 sec
Running main() from gmock_main.cc
[==========] Running 7 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 7 tests from MenuFixture
[ RUN      ] MenuFixture.HelloWorld
[       OK ] MenuFixture.HelloWorld (55 ms)
[ RUN      ] MenuFixture.Header
[       OK ] MenuFixture.Header (53 ms)
[ RUN      ] MenuFixture.Sections
[       OK ] MenuFixture.Sections (55 ms)
[ RUN      ] MenuFixture.Calendar
[       OK ] MenuFixture.Calendar (456 ms)
[ RUN      ] MenuFixture.Appointments
/build/source/tests/test-menus.cpp:330: Failure
Expected equality of these values:
  n_add_event_buttons + 2
    Which is: 3
  g_menu_model_get_n_items(section)
    Which is: 2
/build/source/tests/test-menus.cpp:270: Failure
Expected equality of these values:
  n_add_event_buttons + appointments.size()
    Which is: 3
  g_menu_model_get_n_items(section)
    Which is: 2
/build/source/tests/test-menus.cpp:212: Failure
Expected equality of these values:
  "org.ayatana.indicator.alarm"
  str
    Which is: "org.ayatana.indicator.appointment"
/build/source/tests/test-menus.cpp:239: Failure
Expected equality of these values:
  appt.color
    Which is: "red"
  str
    Which is: "green"
/build/source/tests/test-menus.cpp:250: Failure
Value of: v != nullptr
  Actual: false
Expected: true

(process:2373): GLib-GIO-CRITICAL **: 00:53:13.373: g_icon_deserialize: assertion 'value != NULL' failed
/build/source/tests/test-menus.cpp:252: Failure
Value of: icon != nullptr
  Actual: false
Expected: true
/build/source/tests/test-menus.cpp:214: Failure
Expected equality of these values:
  "org.ayatana.indicator.appointment"
  str
    Which is: NULL
/build/source/tests/test-menus.cpp:219: Failure
Value of: str && *str
  Actual: false
Expected: true
/build/source/tests/test-menus.cpp:234: Failure
Value of: g_menu_model_get_item_attribute(section, index, "x-ayatana-color", "s", &str)
  Actual: false
Expected: true
cleaning up pid 2383
```

</details>