### PR TITLE
separate mkCal Option from Lomiri

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,9 @@ set (PACKAGE ${CMAKE_PROJECT_NAME})
 option(ENABLE_TESTS "Enable all tests and checks" OFF)
 option(ENABLE_COVERAGE "Enable coverage reports (includes enabling all tests and checks)" OFF)
 option(ENABLE_WERROR "Treat all build warnings as errors" OFF)
-option(ENABLE_LOMIRI_FEATURES "Build with Lomiri-specific libraries, schemas, media and backend" OFF)
+option(ENABLE_LOMIRI_FEATURES "Build with Lomiri-specific libraries, schemas, media" OFF)
+option(ENABLE_MKCAL "Use mkcal (libmkcal-qt5) instead of Evolution Data Server backend ( default )" OFF)
+
 
 if(ENABLE_COVERAGE)
     set(ENABLE_TESTS ON)
@@ -76,7 +78,6 @@ if (ENABLE_LOMIRI_FEATURES)
         lomiri-url-dispatcher>=0
         lomiri-sounds
         lomiri-schemas
-        libmkcal-qt5
     )
 
     pkg_get_variable(ALARM_DEFAULT_SOUND lomiri-sounds alarm_default_sound)
@@ -89,18 +90,7 @@ if (ENABLE_LOMIRI_FEATURES)
         -DALARM_DEFAULT_SOUND="${ALARM_DEFAULT_SOUND}"
         -DCALENDAR_DEFAULT_SOUND="${CALENDAR_DEFAULT_SOUND}"
     )
-
-    find_package (ECM REQUIRED NO_MODULE)
-    list (APPEND CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
-    find_package (KF5 COMPONENTS CalendarCore REQUIRED)
 else ()
-    list (
-        APPEND
-        SERVICE_DEPS
-        libecal-2.0>=3.16
-        libedataserver-1.2>=3.5
-        libical>=0.48
-    )
 
     add_definitions (
         -DALARM_DEFAULT_SOUND="dummy"
@@ -108,6 +98,30 @@ else ()
     )
 
     set (ALARM_DEFAULT_SOUND "dummy")
+endif ()
+
+if (ENABLE_MKCAL)
+    list (
+        APPEND
+        SERVICE_DEPS
+        libmkcal-qt5
+    )
+    find_package (ECM REQUIRED NO_MODULE)
+    list (APPEND CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
+    find_package (KF5 COMPONENTS CalendarCore REQUIRED)
+    add_definitions (
+        -DHAS_MKCAL
+    )
+
+else ()
+    # default is EDS
+    list (
+        APPEND
+        SERVICE_DEPS
+        libecal-2.0>=3.16
+        libedataserver-1.2>=3.5
+        libical>=0.48
+    )
 endif ()
 
 pkg_check_modules (SERVICE_DEPS REQUIRED ${SERVICE_DEPS})

--- a/debian/control
+++ b/debian/control
@@ -14,11 +14,11 @@ Build-Depends: cmake,
                libgstreamer1.0-dev,
                libmessaging-menu-dev,
                uuid-dev,
-# for non-Lomiri ICS data storage backend
+# for EDS data storage backend
                libecal2.0-dev (>= 3.16),
                libical-dev (>= 1.0),
                libedataserver1.2-dev (>= 3.5),
-# for Lomiri ICS data storage backend
+# for mkcal data storage backend
                libkf5calendarcore-dev,
                libmkcal-qt5-dev,
 # more Lomiri features
@@ -91,7 +91,7 @@ Description: Lomiri Indicator providing clock and calendar
  Lomiri, this indicator supports phone devices.
  .
  This variant of the datetime indicator has been built for using
- msyncd (mkcal) as ICS data storage backend.
+ evolution-data-server as ICS data storage backend.
 
 Package: ayatana-indicator-datetime-common
 Architecture: any

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,7 @@ set (SERVICE_CXX_SOURCES
      wakeup-timer-mainloop.cpp
      wakeup-timer-powerd.cpp)
 
-if (ENABLE_LOMIRI_FEATURES)
+if (ENABLE_MKCAL)
     list (APPEND SERVICE_CXX_SOURCES engine-mkcal.cpp)
 else ()
     list (APPEND SERVICE_CXX_SOURCES engine-eds.cpp)
@@ -80,7 +80,7 @@ endif()
 include_directories (${CMAKE_SOURCE_DIR})
 link_directories (${SERVICE_DEPS_LIBRARY_DIRS})
 
-if (ENABLE_LOMIRI_FEATURES)
+if (ENABLE_MKCAL)
     set_source_files_properties (engine-mkcal.cpp PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
     target_link_libraries (${SERVICE_LIB} KF5::CalendarCore)
     target_compile_definitions (${SERVICE_LIB} PRIVATE -DQT_DEBUG -DQT_MESSAGELOGCONTEXT)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,7 +77,7 @@ target_link_libraries (${TEST_NAME} indicatordatetimeservice ${SERVICE_DEPS_LIBR
 
 find_program(DBUS_RUNNER dbus-test-runner)
 
-if (ENABLE_LOMIRI_FEATURES)
+if (ENABLE_MKCAL)
     function(add_eds_ics_test_by_name name)
         set (TEST_NAME ${name})
         set (COVERAGE_TEST_TARGETS ${COVERAGE_TEST_TARGETS} ${TEST_NAME} PARENT_SCOPE)

--- a/tests/test-eds-ics-all-day-events.cpp
+++ b/tests/test-eds-ics-all-day-events.cpp
@@ -80,7 +80,7 @@ TEST_F(VAlarmFixture, MultipleAppointments)
 
     // what we expect to get...
     Appointment expected_appt;
-#ifndef LOMIRI_FEATURES_ENABLED
+#ifndef HAS_MKCAL
     expected_appt.uid = "20150521T111538Z-7449-1000-3572-0@ghidorah";
 #else
     expected_appt.uid = "51340540-a924-468e-b3ee-0c0f222cd0f8";
@@ -102,7 +102,7 @@ TEST_F(VAlarmFixture, MultipleAppointments)
     EXPECT_PRED3([](auto sColourIn, auto sColourExpected1, auto sColourExpected2)
     {
         return sColourIn == sColourExpected1 || sColourIn == sColourExpected2;
-#ifndef LOMIRI_FEATURES_ENABLED
+#ifndef HAS_MKCAL
     }, appt.color, "#becedd", "#62a0ea");
 #else
     }, appt.color, "#0000FF", "");

--- a/tests/test-eds-ics-missing-trigger.cpp
+++ b/tests/test-eds-ics-missing-trigger.cpp
@@ -82,7 +82,7 @@ TEST_F(VAlarmFixture, MissingTriggers)
     std::vector<Appointment> expected1;
     Appointment a1;
     a1.type = Appointment::ALARM;
-#ifndef LOMIRI_FEATURES_ENABLED
+#ifndef HAS_MKCAL
     a1.uid = "20150617T211838Z-6217-32011-2036-1@lomiri-phablet";
     a1.color = "#becedd";
 #else
@@ -99,7 +99,7 @@ TEST_F(VAlarmFixture, MissingTriggers)
     expected1.push_back(a1);
 
     // build expected: recurring alarm 1
-#ifndef LOMIRI_FEATURES_ENABLED
+#ifndef HAS_MKCAL
     a1.uid = "20150617T211913Z-6217-32011-2036-5@lomiri-phablet";
 #else
     a1.uid = "3b45cbc9-d5c3-49a4-ad29-acc776818259";
@@ -130,7 +130,7 @@ TEST_F(VAlarmFixture, MissingTriggers)
     std::vector<Appointment> expected2;
     Appointment a2;
     a2.type = Appointment::ALARM;
-#ifndef LOMIRI_FEATURES_ENABLED
+#ifndef HAS_MKCAL
     a2.uid = "20150617T211838Z-6217-32011-2036-1@lomiri-phablet";
     a2.color = "#62a0ea";
 #else
@@ -147,7 +147,7 @@ TEST_F(VAlarmFixture, MissingTriggers)
     expected2.push_back(a2);
 
     // build expected: recurring alarm 2
-#ifndef LOMIRI_FEATURES_ENABLED
+#ifndef HAS_MKCAL
     a2.uid = "20150617T211913Z-6217-32011-2036-5@lomiri-phablet";
 #else
     a2.uid = "3b45cbc9-d5c3-49a4-ad29-acc776818259";

--- a/tests/test-eds-ics-nonrepeating-events.cpp
+++ b/tests/test-eds-ics-nonrepeating-events.cpp
@@ -80,7 +80,7 @@ TEST_F(VAlarmFixture, MultipleAppointments)
 
     // what we expect to get...
     Appointment expected_appt;
-#ifndef LOMIRI_FEATURES_ENABLED
+#ifndef HAS_MKCAL
     expected_appt.uid = "20150520T000726Z-3878-32011-1770-81@lomiri-phablet";
 #else
     expected_appt.uid = "d7aeb192-8b2c-4427-834f-f30388e9e73c";
@@ -103,7 +103,7 @@ TEST_F(VAlarmFixture, MultipleAppointments)
         EXPECT_PRED3([](auto sColourIn, auto sColourExpected1, auto sColourExpected2)
         {
             return sColourIn == sColourExpected1 || sColourIn == sColourExpected2;
-    #ifndef LOMIRI_FEATURES_ENABLED
+    #ifndef HAS_MKCAL
         }, appt.color, "#becedd", "#62a0ea");
     #else
         }, appt.color, "#0000FF", "");

--- a/tests/test-eds-ics-repeating-events.cpp
+++ b/tests/test-eds-ics-repeating-events.cpp
@@ -80,7 +80,7 @@ TEST_F(VAlarmFixture, MultipleAppointments)
 
     // what we expect to get...
     Appointment expected_appt;
-#ifndef LOMIRI_FEATURES_ENABLED
+#ifndef HAS_MKCAL
     expected_appt.uid = "20150507T211449Z-4262-32011-1418-1@lomiri-phablet";
 #else
     expected_appt.uid = "840ab899-1b0e-4697-9514-dcd336a5e125";
@@ -110,7 +110,7 @@ TEST_F(VAlarmFixture, MultipleAppointments)
         EXPECT_PRED3([](auto sColourIn, auto sColourExpected1, auto sColourExpected2)
         {
             return sColourIn == sColourExpected1 || sColourIn == sColourExpected2;
-    #ifndef LOMIRI_FEATURES_ENABLED
+    #ifndef HAS_MKCAL
         }, appt.color, "#becedd", "#62a0ea");
     #else
         }, appt.color, "#0000FF", "");

--- a/tests/test-eds-ics-tzids-2.cpp
+++ b/tests/test-eds-ics-tzids-2.cpp
@@ -81,7 +81,7 @@ TEST_F(VAlarmFixture, MultipleAppointments)
     // what we expect to get...
     std::array<Appointment,1> expected_appts1;
     auto appt1 = &expected_appts1[0];
-#ifndef LOMIRI_FEATURES_ENABLED
+#ifndef HAS_MKCAL
     appt1->uid = "109264742";
     appt1->color = "#becedd";
 #else
@@ -95,7 +95,7 @@ TEST_F(VAlarmFixture, MultipleAppointments)
 
     std::array<Appointment,1> expected_appts2;
     auto appt2 = &expected_appts2[0];
-#ifndef LOMIRI_FEATURES_ENABLED
+#ifndef HAS_MKCAL
     appt2->uid = "109264742";
     appt2->color = "#62a0ea";
 #else

--- a/tests/test-eds-ics-tzids-utc.cpp
+++ b/tests/test-eds-ics-tzids-utc.cpp
@@ -82,7 +82,7 @@ TEST_F(VAlarmFixture, UTCAppointments)
     // what we expect to get...
     std::array<Appointment,1> expected_appts1;
     auto appt1 = &expected_appts1[0];
-#ifndef LOMIRI_FEATURES_ENABLED
+#ifndef HAS_MKCAL
     appt1->uid = "20160322T132738Z";
     appt1->color = "#becedd";
 #else
@@ -95,7 +95,7 @@ TEST_F(VAlarmFixture, UTCAppointments)
 
     std::array<Appointment,1> expected_appts2;
     auto appt2 = &expected_appts2[0];
-#ifndef LOMIRI_FEATURES_ENABLED
+#ifndef HAS_MKCAL
     appt2->uid = "20160322T132738Z";
     appt2->color = "#62a0ea";
 #else

--- a/tests/test-eds-ics-tzids.cpp
+++ b/tests/test-eds-ics-tzids.cpp
@@ -81,7 +81,7 @@ TEST_F(VAlarmFixture, MultipleAppointments)
     // what we expect to get...
     std::array<Appointment,1> expected_appts1;
     auto appt1 = &expected_appts1[0];
-#ifndef LOMIRI_FEATURES_ENABLED
+#ifndef HAS_MKCAL
     appt1->uid = "8ggc30kh89qql8vjumgtug7l14@google.com";
     appt1->color = "#becedd";
 #else
@@ -94,7 +94,7 @@ TEST_F(VAlarmFixture, MultipleAppointments)
 
     std::array<Appointment,1> expected_appts2;
     auto appt2 = &expected_appts2[0];
-#ifndef LOMIRI_FEATURES_ENABLED
+#ifndef HAS_MKCAL
     appt2->uid = "8ggc30kh89qql8vjumgtug7l14@google.com";
     appt2->color = "#62a0ea";
 #else


### PR DESCRIPTION
We should be able to build ADT with Lomiri and EDS by default.
Then add mkcal as an option